### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,11 @@ A lot services on IBM Cloud have the lite tier, that you can use with your free 
 - [Node-RED](https://developer.ibm.com/components/node-red/)
 - [Node-RED Docs](https://nodered.org/docs/)
 
-## Covid19 resources
-- [Resources from Call for Code](https://developer.ibm.com/callforcode/get-started/covid-19/)
-- [Node-RED Covid charts](https://github.com/call-for-code/node-red-contrib-twc-covid19-tracker)
+## Climate Change resources
+- [Water Sustainability Starter Kit](https://developer.ibm.com/callforcode/get-started/climate-change/water-sustainability/)
+- [Energy Sustainability Starter Kit](https://developer.ibm.com/callforcode/get-started/climate-change/energy-sustainability/)
+- [Disaster Resiliency Starter Kit](https://developer.ibm.com/callforcode/get-started/climate-change/disaster-resiliency/)
+- [Call for Code On-Demand](https://developer.ibm.com/conferences/c4cdc-take-on-climate-change/)
 
 ## Build fast with IBM Cloud videos
 - [Deploy Angular.js application on IBM CLoud](https://www.youtube.com/watch?v=xu6nEY2Y03A)


### PR DESCRIPTION
Substituting COVID resources for last year's climate change resources.
You may know better than I, but are any of these starter kits no longer valid? I feel like the water sustainability starter kit may leverage a weather company API that is no longer available. I asked John Walicki about it, but haven't heard back yet.